### PR TITLE
fix: Obtaining points in GetEdgesOfTriangle

### DIFF
--- a/DelaunatorSharp/Delaunator.cs
+++ b/DelaunatorSharp/Delaunator.cs
@@ -619,7 +619,7 @@ namespace DelaunatorSharp
             return points.ToArray();
         }
 
-        public IEnumerable<IEdge> GetEdgesOfTriangle(int t) => CreateHull(EdgesOfTriangle(t).Select(p => Points[p]));
+        public IEnumerable<IEdge> GetEdgesOfTriangle(int t) => CreateHull(EdgesOfTriangle(t).Select(e => Points[Triangles[e]]));
         public static IEnumerable<IEdge> CreateHull(IEnumerable<IPoint> points) => points.Zip(points.Skip(1).Append(points.FirstOrDefault()), (a, b) => new Edge(0, a, b)).OfType<IEdge>();
         public IPoint GetTriangleCircumcenter(int t)
         {


### PR DESCRIPTION
This fixes an issue with `GetEdgesOfTriangle` where half-edge indices were being used to obtain points. It will now first convert the half-edge index to its corresponding point index before performing the lookup.

## Issue

If I grab an edge index and draw its point:
```csharp
var delaunator = new Delaunator(points);
var e = delaunator.Halfedges.Count() / 4;
var p = delaunator.Points[delaunator.Triangles[e]];
DrawCircle(p, 4.0f, Colors.Lime);
```
I can see the point:
![voronoi_no_triangle_edges](https://github.com/user-attachments/assets/6a659349-86ec-4be1-b955-383e29f723f2)

But if I then try to also draw the edges of the Triangle that edge is associated with:
```csharp
var t = Delaunator.TriangleOfEdge(e);
var edges = delaunator.GetEdgesOfTriangle(t);
foreach (var edge in edges)
{
    DrawLine(edge.P, edge.Q, Colors.HotPink);
    DrawCircle(edge.P, 2.0f, Colors.Green);
}
```

I get an IndexOutOfRangeException: 
```
E 0:00:00:0814   void Internal.Runtime.CompilerHelpers.ThrowHelpers.ThrowIndexOutOfRangeException(): System.IndexOutOfRangeException: Index was outside the bounds of the array.
...
                 :0 @ DelaunatorSharp.IPoint DelaunatorSharp.Delaunator.<GetEdgesOfTriangle>b__54_0(int)
                 :0 @ TResult System.Linq.Enumerable+ArraySelectIterator`2.TryGetFirst(System.Boolean&)
                 :0 @ TSource System.Linq.Enumerable.FirstOrDefault<TSource>(System.Collections.Generic.IEnumerable`1[TSource])
                 :0 @ System.Collections.Generic.IEnumerable`1[DelaunatorSharp.IEdge] DelaunatorSharp.Delaunator.CreateHull(System.Collections.Generic.IEnumerable`1[DelaunatorSharp.IPoint])
                 :0 @ System.Collections.Generic.IEnumerable`1[DelaunatorSharp.IEdge] DelaunatorSharp.Delaunator.GetEdgesOfTriangle(int)
```

## Fix
If I use the following extension method in place of `Delaunator.GetEdgesOfTriangle`:
```csharp
public static IEnumerable<IEdge> GetEdgesOfTriangleFixed(this Delaunator delaunator, int t) =>
    Delaunator.CreateHull(
        Delaunator.EdgesOfTriangle(t).Select(e => delaunator.Points[delaunator.Triangles[e]])
    );
```
I can then see the triangle drawn correctly:
![voronoi_triangle_edges](https://github.com/user-attachments/assets/e9569935-636a-4d86-8441-e9f4428553cd)
